### PR TITLE
[BUGFIX] Fixed a bug in RandomType

### DIFF
--- a/src/main/java/org/parabot/environment/randoms/RandomType.java
+++ b/src/main/java/org/parabot/environment/randoms/RandomType.java
@@ -6,9 +6,9 @@ package org.parabot.environment.randoms;
 public enum RandomType {
 
     SCRIPT(0, "Script"),
-    ON_SCRIPT_START(0, "On script start"),
-    ON_SERVER_START(0, "On server start"),
-    ON_SCRIPT_FINISH(0, "On script finish");
+    ON_SCRIPT_START(1, "On script start"),
+    ON_SERVER_START(2, "On server start"),
+    ON_SCRIPT_FINISH(3, "On script finish");
 
     private int id;
     private String name;


### PR DESCRIPTION
Provide a general summary of your changes in the **Title** above.

### Important
Mark with [x] to select. Leave as [ ] to unselect.
If possible; include a screenshot or gif of the change you've made

### Motivation and Context
Each item you can check should be described in the _Description_ section.

- [ ] Why is this change required? What problem does it solve?
- [ ] If it fixes an open issue, include the text `Closes issue #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cleanup (non-breaking change which cleans up the code)

### Final checklist
Go over all the following points and check all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help! 
Various areas of the codebase have been worked on by different people in recent years, so if you are unfamiliar with the general area you're working in, please feel free to chat with people who have experience in that area.

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have tested the functionality
- [ ] I have added tests for this functionality

Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation.

If it reports back that there are problems, you go to [the Travis system](https://travis-ci.org/Parabot/Parabot) and check the log report for your pull request to see what the problem was.
If you add new code to fix a Travis building issue/problem, then take note that you need to check the next pull request in the Travis system.
Travis issue numbers are different from GitHub issue numbers.

### Description
The id’s for the types were all the same.