### PR TITLE
Add button to manually trigger randoms

### DIFF
--- a/src/main/java/org/parabot/Landing.java
+++ b/src/main/java/org/parabot/Landing.java
@@ -135,6 +135,12 @@ public final class Landing {
                 case "-no_validation":
                     Core.disableValidation();
                     break;
+                case "-nobdn":
+                    Core.setLoadBdn(false);
+                    break;
+                case "-skiplogin":
+                    Core.setSkipLogin(true);
+                    break;
             }
         }
     }

--- a/src/main/java/org/parabot/Landing.java
+++ b/src/main/java/org/parabot/Landing.java
@@ -41,7 +41,7 @@ public final class Landing {
             t.printStackTrace();
         }
 
-        if (!Core.inDebugMode() && Core.hasValidation() && !Core.isValid()) {
+        if (Core.hasValidation() && !Core.isValid()) {
             if (Core.newVersionAlert() == JOptionPane.YES_OPTION) {
                 Core.downloadNewVersion();
                 return;

--- a/src/main/java/org/parabot/core/Core.java
+++ b/src/main/java/org/parabot/core/Core.java
@@ -28,22 +28,45 @@ import java.security.NoSuchAlgorithmException;
 @SuppressWarnings("Duplicates")
 public class Core {
 
-    private static boolean debug;
+    private static boolean debug; // in debug mode, we will print more detailed error messages.
     private static boolean verbose;
     private static boolean dump;
     private static boolean loadLocal; //Loads both local and public scripts/servers
+    private static boolean skipLogin; // default false, we won't skip login.
 
-    private static boolean validate = true;
+    private static boolean validate = true; // default true, always check for new parabot versions.
     private static boolean secure   = true;
+    private static boolean loadBdn   = true; // default true, loading BDN scripts and servers.
+
 
     private static Version currentVersion = Configuration.BOT_VERSION;
 
+    /**
+     * Set if we are to load BDN servers and scripts, or skip.
+     * @param loadBdn
+     */
+    public static void setLoadBdn(boolean loadBdn) {
+        Core.loadBdn = loadBdn;
+    }
+
+    /**
+     * Turn off checking for newer parabot versions.
+     */
     public static void disableValidation() {
         Core.validate = false;
     }
 
     public static boolean hasValidation() {
         return validate;
+    }
+
+
+    /**
+     * If you want to skip parabot login.
+     * @param skipLogin
+     */
+    public static void setSkipLogin(boolean skipLogin) {
+        Core.skipLogin = skipLogin;
     }
 
     /**
@@ -255,5 +278,13 @@ public class Core {
      */
     public static int newVersionAlert() {
         return UILog.alert("Parabot Update", "There's a new version of Parabot! \nDo you wish to download it?\n\nThe current version could have some problems!", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+    }
+
+    public static boolean skipLogin() {
+        return skipLogin;
+    }
+
+    public static boolean loadBdn() {
+        return loadBdn;
     }
 }

--- a/src/main/java/org/parabot/core/parsers/scripts/BDNScripts.java
+++ b/src/main/java/org/parabot/core/parsers/scripts/BDNScripts.java
@@ -1,12 +1,16 @@
 package org.parabot.core.parsers.scripts;
 
+import javax.swing.JOptionPane;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.parabot.core.Configuration;
 import org.parabot.core.Context;
+import org.parabot.core.Core;
 import org.parabot.core.desc.ScriptDescription;
 import org.parabot.core.forum.AccountManager;
 import org.parabot.core.forum.AccountManagerAccess;
+import org.parabot.core.ui.Logger;
+import org.parabot.core.ui.utils.UILog;
 import org.parabot.environment.api.utils.WebUtil;
 import org.parabot.environment.scripts.executers.BDNScriptsExecuter;
 
@@ -33,7 +37,12 @@ public class BDNScripts extends ScriptParser {
     @Override
     public void execute() {
         if (!manager.isLoggedIn()) {
-            System.err.println("Not logged in...");
+            System.err.println("Scripts from the BDN cannot be loaded because you are not logged into your Parabot Account.");
+            Logger.addMessage("Scripts from the BDN cannot be loaded because you are not logged into your Parabot Account.");
+            if (!Core.inLoadLocal()) {
+                // This alert is suppressed in loadlocal mode, since any existing local scripts will be displayed.
+                UILog.log("BDN Scripts", "Scripts from the BDN cannot be loaded \nbecause you are not logged into your\nParabot Account.");
+            }
             return;
         }
 

--- a/src/main/java/org/parabot/core/parsers/scripts/ScriptParser.java
+++ b/src/main/java/org/parabot/core/parsers/scripts/ScriptParser.java
@@ -21,12 +21,11 @@ public abstract class ScriptParser {
     public static ScriptDescription[] getDescriptions() {
         SCRIPT_CACHE.clear();
         final ArrayList<ScriptParser> parsers = new ArrayList<ScriptParser>();
+
         if (Core.inLoadLocal()) {
             parsers.add(new LocalJavaScripts());
-            parsers.add(new BDNScripts());
-        } else if (Core.inDebugMode()) {
-            parsers.add(new LocalJavaScripts());
-        } else {
+        }
+        if (Core.loadBdn()) {
             parsers.add(new BDNScripts());
         }
 

--- a/src/main/java/org/parabot/core/parsers/servers/PublicServers.java
+++ b/src/main/java/org/parabot/core/parsers/servers/PublicServers.java
@@ -55,8 +55,8 @@ public class PublicServers extends ServerParser {
             br.close();
 
         } catch (Exception e) {
-            UILog.log("Error", "Failed to load public servers. Either disable your anti-virus or request support on the forums.", JOptionPane.ERROR_MESSAGE);
             e.printStackTrace();
+            UILog.log("Error", "Failed to load public servers. Either disable your anti-virus or request support on the forums.", JOptionPane.ERROR_MESSAGE);
         }
     }
 }

--- a/src/main/java/org/parabot/core/parsers/servers/ServerParser.java
+++ b/src/main/java/org/parabot/core/parsers/servers/ServerParser.java
@@ -20,12 +20,11 @@ public abstract class ServerParser {
     public static final ServerDescription[] getDescriptions() {
         SERVER_CACHE.clear();
         final ArrayList<ServerParser> parsers = new ArrayList<>();
+
         if (Core.inLoadLocal()) {
             parsers.add(new LocalServers());
-            parsers.add(new PublicServers());
-        } else if (Core.inDebugMode()) {
-            parsers.add(new LocalServers());
-        } else {
+        }
+        if (Core.loadBdn()) {
             parsers.add(new PublicServers());
         }
 

--- a/src/main/java/org/parabot/core/ui/RandomUI.java
+++ b/src/main/java/org/parabot/core/ui/RandomUI.java
@@ -1,5 +1,6 @@
 package org.parabot.core.ui;
 
+import java.awt.Button;
 import org.parabot.core.Context;
 import org.parabot.core.Core;
 import org.parabot.environment.randoms.Random;
@@ -40,8 +41,14 @@ public class RandomUI implements ActionListener {
         if (randoms.size() > 0) {
             checkBoxes = new ArrayList<>();
             for (int i = 0; i < randoms.size(); i++) {
+
+                Button btn = new Button("Run now: "+randoms.get(i));
+                btn.setBounds(6, 35 + (i * 35), 200, 23);
+                btn.addActionListener(this);
+                frame.getContentPane().add(btn);
+
                 JCheckBox checkBox = new JCheckBox(randoms.get(i));
-                checkBox.setBounds(6, 35 + (i * 35), 250, 23);
+                checkBox.setBounds((int)btn.getBounds().getMaxX()+10, 35 + (i * 35), 250, 23);
                 frame.getContentPane().add(checkBox);
                 if (isActive(randoms.get(i))) {
                     checkBox.setSelected(true);
@@ -61,20 +68,31 @@ public class RandomUI implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        Context.getInstance().getRandomHandler().clearActiveRandoms();
-        if (checkBoxes != null && checkBoxes.size() > 0) {
-            for (JCheckBox checkBox : this.checkBoxes) {
-                if (checkBox.isSelected()) {
-                    for (Random r : Context.getInstance().getRandomHandler().getRandoms()) {
-                        if (r.getName().equalsIgnoreCase(checkBox.getText().toLowerCase())) {
-                            Core.verbose("Actived random '" + r.getName() + "'");
-                            Context.getInstance().getRandomHandler().setActive(r.getName());
+        org.parabot.api.output.Logger.debug("RandomUI", e.toString()+" | "+e.getActionCommand());
+        if (e.getActionCommand().startsWith("Run now: ")) {
+            org.parabot.api.output.Logger.debug("RandomUI", e.getActionCommand().substring(9));
+            for (Random r : Context.getInstance().getRandomHandler().getRandoms()) {
+                if (r.getName().equalsIgnoreCase(e.getActionCommand().substring(9))) {
+                    Core.verbose("Executing random '" + r.getName() + "'");
+                    Context.getInstance().getRandomHandler().executeRandom(r);
+                }
+            }
+        } else {
+            Context.getInstance().getRandomHandler().clearActiveRandoms();
+            if (checkBoxes != null && checkBoxes.size() > 0) {
+                for (JCheckBox checkBox : this.checkBoxes) {
+                    if (checkBox.isSelected()) {
+                        for (Random r : Context.getInstance().getRandomHandler().getRandoms()) {
+                            if (r.getName().equalsIgnoreCase(checkBox.getText().toLowerCase())) {
+                                Core.verbose("Actived random '" + r.getName() + "'");
+                                Context.getInstance().getRandomHandler().setActive(r.getName());
+                            }
                         }
                     }
                 }
             }
+            this.frame.dispose();
         }
-        this.frame.dispose();
     }
 
     private boolean isActive(String random) {

--- a/src/main/java/org/parabot/core/ui/components/VerboseLoader.java
+++ b/src/main/java/org/parabot/core/ui/components/VerboseLoader.java
@@ -61,7 +61,7 @@ public class VerboseLoader extends JPanel implements ProgressListener {
         setOpaque(false);
 
         if (username != null && password != null) {
-            if (Core.inDebugMode() || manager.login(username, password, false)) {
+            if (Core.skipLogin() || manager.login(username, password, false)) {
                 currentState = STATE_SERVER_SELECT;
             }
         }


### PR DESCRIPTION
![alt](https://i.imgur.com/BUU9M4D.jpg)

RuneWild re-loads your MAC address saved in a local file just before login, rather than the usual place on client initialization. This means the normal triggers in RandomType aren't applied at the right time to bypass the MAC limit. 

```
public enum RandomType {
    SCRIPT(0, "Script"),
    ON_SCRIPT_START(1, "On script start"),
    ON_SERVER_START(2, "On server start"),
    ON_SCRIPT_FINISH(3, "On script finish");
}
```
With this PR you can trigger the MAC fix manually before logging in and it'll work. 