### PR TITLE
Add waypoint methods for Applet pre init and post start

### DIFF
--- a/src/main/java/org/parabot/core/Context.java
+++ b/src/main/java/org/parabot/core/Context.java
@@ -185,8 +185,12 @@ public class Context {
         panel.add(gameApplet);
         panel.validate();
 
+        serverProvider.preAppletInit();
+
         gameApplet.init();
         gameApplet.start();
+
+        serverProvider.postAppletStart();
 
         java.util.Timer t = new java.util.Timer();
         t.schedule(new TimerTask() {

--- a/src/main/java/org/parabot/environment/servers/ServerProvider.java
+++ b/src/main/java/org/parabot/environment/servers/ServerProvider.java
@@ -146,4 +146,20 @@ public abstract class ServerProvider implements Opcodes {
 
     }
 
+    /**
+     * Called in Context.setApplet before applet.init() is called. Exclusively used for manipulating the Frame attached
+     * to the applet of Roatpkz.
+     */
+    public void preAppletInit() {
+
+    }
+
+    /**
+     * Called in Context.setApplet before after applet.start()  and applet.init() are called. Exclusively used for manipulating the Frame attached
+     * to the applet of Roatpkz.
+     */
+    public void postAppletStart() {
+
+    }
+
 }


### PR DESCRIPTION
Required for solution to embedding RoatPkz Applet into the Parabot GamePanel (see also: RoatPkz-317-min PR)