### PR TITLE
Bugfix/zeroarg callbacks

### DIFF
--- a/src/main/java/org/parabot/core/asm/adapters/AddCallbackAdapter.java
+++ b/src/main/java/org/parabot/core/asm/adapters/AddCallbackAdapter.java
@@ -40,17 +40,19 @@ public class AddCallbackAdapter implements Injectable, Opcodes {
         Label        l0     = new Label();
         inject.add(new LabelNode(l0));
         int offset = 0;
-        for (int arg : args) {
-            if (Modifier.isStatic(method.access)) {
-                int loadOpcode = ASMUtils.getLoadOpcode(types[arg]
-                        .getDescriptor());
-                inject.add(new VarInsnNode(loadOpcode, arg + offset));
-                if (loadOpcode == Opcodes.LLOAD) {
-                    offset++;
+        if (args != null && args.length > 0) {
+            for (int arg : args) {
+                if (Modifier.isStatic(method.access)) {
+                    int loadOpcode = ASMUtils.getLoadOpcode(types[arg]
+                            .getDescriptor());
+                    inject.add(new VarInsnNode(loadOpcode, arg + offset));
+                    if (loadOpcode == Opcodes.LLOAD) {
+                        offset++;
+                    }
+                } else {
+                    inject.add(new VarInsnNode(ASMUtils.getLoadOpcode(types[arg]
+                            .getDescriptor()), arg + 1));
                 }
-            } else {
-                inject.add(new VarInsnNode(ASMUtils.getLoadOpcode(types[arg]
-                        .getDescriptor()), arg + 1));
             }
         }
         inject.add(new MethodInsnNode(INVOKESTATIC,

--- a/src/main/java/org/parabot/core/asm/adapters/AddCallbackAdapter.java
+++ b/src/main/java/org/parabot/core/asm/adapters/AddCallbackAdapter.java
@@ -40,7 +40,7 @@ public class AddCallbackAdapter implements Injectable, Opcodes {
         Label        l0     = new Label();
         inject.add(new LabelNode(l0));
         int offset = 0;
-        if (args != null && args.length > 0) {
+        if (args != null) {
             for (int arg : args) {
                 if (Modifier.isStatic(method.access)) {
                     int loadOpcode = ASMUtils.getLoadOpcode(types[arg]

--- a/src/main/java/org/parabot/core/asm/wrappers/Callback.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Callback.java
@@ -26,14 +26,16 @@ public class Callback implements Injectable {
         this.invokeMethod = callbackMethod;
         this.desc = callbackDesc;
         this.conditional = conditional;
-        if (args.contains(",")) {
-            final String[] strArgs = args.split(",");
-            this.args = new int[strArgs.length];
-            for (int i = 0; i < this.args.length; i++) {
-                this.args[i] = Integer.parseInt(strArgs[i]);
+        if (args.length() > 0) {
+            if (args.contains(",")) {
+                final String[] strArgs = args.split(",");
+                this.args = new int[strArgs.length];
+                for (int i = 0; i < this.args.length; i++) {
+                    this.args[i] = Integer.parseInt(strArgs[i]);
+                }
+            } else {
+                this.args = new int[]{Integer.parseInt(args)};
             }
-        } else {
-            this.args = new int[]{ Integer.parseInt(args) };
         }
     }
 

--- a/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
@@ -67,6 +67,12 @@ public class XMLHookParser extends HookParser {
     private static final String getValue(String tag, Element element) {
         NodeList nodes = element.getElementsByTagName(tag).item(0)
                 .getChildNodes();
+        if (nodes.getLength() == 0 || nodes.item(0) == null) {
+            if (Core.inVerboseMode()) {
+                System.err.println("WARNING: Invalid Hook "+tag+" subnode. Tag is missing or empty?");
+            }
+            return "";
+        }
         Node node = (Node) nodes.item(0);
         return node.getNodeValue();
     }

--- a/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
@@ -65,6 +65,9 @@ public class XMLHookParser extends HookParser {
     }
 
     private static final String getValue(String tag, Element element) {
+        if (element.getElementsByTagName(tag).item(0) == null) {
+            throw new NullPointerException("MISSING HOOK TAG: The '"+tag+"' xml tag is missing from one of the hooks of type: "+element.getParentNode().getNodeName());
+        }
         NodeList nodes = element.getElementsByTagName(tag).item(0)
                 .getChildNodes();
         if (nodes.getLength() == 0 || nodes.item(0) == null) {

--- a/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
@@ -66,13 +66,13 @@ public class XMLHookParser extends HookParser {
 
     private static final String getValue(String tag, Element element) {
         if (element.getElementsByTagName(tag).item(0) == null) {
-            throw new NullPointerException("MISSING HOOK TAG: The '"+tag+"' xml tag is missing from one of the hooks of type: "+element.getParentNode().getNodeName());
+            throw new NullPointerException("MISSING HOOK TAG: The '" + tag + "' xml tag is missing from one of the hooks of type: " + element.getParentNode().getNodeName());
         }
         NodeList nodes = element.getElementsByTagName(tag).item(0)
                 .getChildNodes();
         if (nodes.getLength() == 0 || nodes.item(0) == null) {
             if (Core.inVerboseMode()) {
-                System.err.println("WARNING: Invalid Hook "+tag+" subnode. Tag is missing or empty?");
+                System.err.println("WARNING: Invalid Hook " + tag + " subnode. Tag is missing or empty?");
             }
             return "";
         }


### PR DESCRIPTION
Previously an NPE would be thrown if the Callargs XML tag was missing or empty. Now it is allowed to be empty if the callback and hooked method has no arguments to parse, such as `()V`