### PR TITLE
[Bugfix] ServerDescription comparitor fix

### DIFF
--- a/src/main/java/org/parabot/core/desc/ServerDescription.java
+++ b/src/main/java/org/parabot/core/desc/ServerDescription.java
@@ -39,7 +39,10 @@ public class ServerDescription implements Comparable<ServerDescription> {
     @Override
     public int compareTo(ServerDescription o) {
         if (this.getServerName().equalsIgnoreCase(o.getServerName())) {
-            return 1;
+            if (getAuthor().equals(o.getAuthor())) {
+                return Double.compare(o.getRevision(), getRevision());
+            }
+            return getAuthor().compareTo(o.getAuthor());
         }
         return this.getServerName().compareTo(o.getServerName());
     }


### PR DESCRIPTION
Proper solution, allows BDN and local servers to both display if matching name, author or version, in order.