### PR TITLE
Added catch for broken hooks - fix issue #188

### DIFF
--- a/src/main/java/org/parabot/core/asm/wrappers/Callback.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Callback.java
@@ -49,4 +49,19 @@ public class Callback implements Injectable {
                 this.invokeMethod, this.desc, this.args, this.conditional);
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("Injectable type: Callback");
+
+        if(method != null) {
+            sb.append(", intercepts method: ").append(method.name);
+        }
+
+        sb.append(", calls class: ").append(invokeClass)
+                .append(", calls method: ").append(invokeMethod);
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/org/parabot/core/asm/wrappers/Getter.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Getter.java
@@ -38,7 +38,7 @@ public class Getter implements Injectable {
         this.fieldLocation = ASMUtils.getClass(fieldLocation);
         this.fieldNode = ASMUtils.getField(ASMUtils.getClass(fieldLocation), fieldNode, fieldDesc);
         this.methodName = methodName;
-        this.returnDesc = returnDesc == null ? this.fieldNode.desc : returnDesc;
+        this.returnDesc = returnDesc == null && this.fieldNode != null ? this.fieldNode.desc : returnDesc;
         this.staticMethod = staticMethod;
         this.multiplier = multiplier;
         Core.verbose(methodName + "[" + fieldLocation + "." + fieldNode + "]");
@@ -77,4 +77,21 @@ public class Getter implements Injectable {
         return new AddGetterAdapter(into, fieldLocation, fieldNode, methodName, returnDesc, staticMethod, multiplier);
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Injectable type: Getter");
+
+        if(fieldLocation.interfaces.size() > 0) {
+            sb.append(", accessor type: ").append(fieldLocation.interfaces.get(0).toString().replace('/', '.'));
+        }
+
+        if(fieldNode != null) {
+            sb.append(", field: ").append(fieldNode.name);
+        }
+
+        sb.append(", method name: ").append(methodName);
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/org/parabot/core/asm/wrappers/Getter.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Getter.java
@@ -38,7 +38,7 @@ public class Getter implements Injectable {
         this.fieldLocation = ASMUtils.getClass(fieldLocation);
         this.fieldNode = ASMUtils.getField(ASMUtils.getClass(fieldLocation), fieldNode, fieldDesc);
         this.methodName = methodName;
-        this.returnDesc = returnDesc == null && this.fieldNode != null ? this.fieldNode.desc : returnDesc;
+        this.returnDesc = (returnDesc == null && this.fieldNode != null) ? this.fieldNode.desc : returnDesc;
         this.staticMethod = staticMethod;
         this.multiplier = multiplier;
         Core.verbose(methodName + "[" + fieldLocation + "." + fieldNode + "]");

--- a/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
@@ -79,4 +79,12 @@ public class Invoker implements Injectable {
                 this.argsDesc, this.returnDesc, this.methodName, this.isInterface, this.instanceCast, this.argsCheckCastDesc);
     }
 
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("Injectable type: Invoker")
+                .append(", accessor: ").append(methodLocation.name)
+                .append(", method name: ").append(methodName)
+                .append(", invokes method: ").append(mName).toString();
+    }
 }

--- a/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
@@ -81,10 +81,6 @@ public class Invoker implements Injectable {
 
     @Override
     public String toString() {
-        return new StringBuilder()
-                .append("Injectable type: Invoker")
-                .append(", accessor: ").append(methodLocation.name)
-                .append(", method name: ").append(methodName)
-                .append(", invokes method: ").append(mName).toString();
+        return String.format("Injectable type: Invoker, accessor: %s, method name: %s, invokes method: %s", methodLocation.name, methodName, mName);
     }
 }

--- a/src/main/java/org/parabot/core/asm/wrappers/Setter.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Setter.java
@@ -25,7 +25,7 @@ public class Setter implements Injectable {
         this.into = ASMUtils.getClass(into);
         this.field = ASMUtils.getField(this.fieldLocation, fieldName, fieldDesc);
         this.name = methodName;
-        this.desc = (desc == null) ? this.field.desc : desc;
+        this.desc = (desc == null) && this.field != null ? this.field.desc : desc;
         this.methodStatic = methodStatic;
     }
 
@@ -52,4 +52,21 @@ public class Setter implements Injectable {
         return new AddSetterAdapter(fieldLocation, into, field, name, desc, methodStatic);
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Injectable type: Setter");
+
+        if(fieldLocation.interfaces.size() > 0) {
+            sb.append(", accessor type: ").append(fieldLocation.interfaces.get(0).toString().replace('/', '.'));
+        }
+
+        if(field != null) {
+            sb.append(", field: ").append(field.name);
+        }
+
+        sb.append(", method name: ").append(name);
+
+        return sb.toString();
+    }
 }

--- a/src/main/java/org/parabot/core/asm/wrappers/Setter.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Setter.java
@@ -25,7 +25,7 @@ public class Setter implements Injectable {
         this.into = ASMUtils.getClass(into);
         this.field = ASMUtils.getField(this.fieldLocation, fieldName, fieldDesc);
         this.name = methodName;
-        this.desc = (desc == null) && this.field != null ? this.field.desc : desc;
+        this.desc = (desc == null && this.field != null) ? this.field.desc : desc;
         this.methodStatic = methodStatic;
     }
 

--- a/src/main/java/org/parabot/environment/servers/ServerProvider.java
+++ b/src/main/java/org/parabot/environment/servers/ServerProvider.java
@@ -5,6 +5,7 @@ import org.parabot.core.Context;
 import org.parabot.core.asm.hooks.HookFile;
 import org.parabot.core.asm.interfaces.Injectable;
 import org.parabot.core.parsers.hooks.HookParser;
+import org.parabot.core.ui.utils.UILog;
 import org.parabot.environment.input.Keyboard;
 import org.parabot.environment.input.Mouse;
 import org.parabot.environment.scripts.Script;
@@ -21,6 +22,7 @@ import java.net.URL;
  * @author Everel
  */
 public abstract class ServerProvider implements Opcodes {
+    private boolean crashed = false;
 
     /**
      * Get the game/applet dimensions
@@ -74,12 +76,29 @@ public abstract class ServerProvider implements Opcodes {
 
         HookParser   parser      = hookFile.getParser();
         Injectable[] injectables = parser.getInjectables();
+
         if (injectables == null) {
             return;
         }
-        for (Injectable inj : injectables) {
-            inj.inject();
+
+        int index = 0;
+
+        try {
+            for (Injectable inj : injectables) {
+                inj.inject();
+                index++;
+            }
+        } catch (NullPointerException ex) {
+            if(!crashed) {
+                Injectable inj = injectables[index];
+
+                UILog.log("Outdated client", "This server currently has outdated hooks, please report it to a member of the Parabot staff/Dev Team.\r\n\r\n" +
+                        "Broken hook:\r\n"+inj, JOptionPane.ERROR_MESSAGE);
+            }
+            crashed = true;
+            throw ex;
         }
+
         Context.getInstance().setHookParser(parser);
     }
 


### PR DESCRIPTION
Current dialog example: http://prntscr.com/lnjna5

Had to add conditions at `Getter:41` and `Setter:28` to move some errors from `ServerProvider:78` to `ServerProvider:88` so all errors happen in the same place (some hooks crashed when initiating the wrapper some when initiating the adapter). Now they all happen when initiating the adapter so I can grab the Injector and display the troubled hook.

Related to issue #188 