### PR TITLE
Added bit version check at startup

### DIFF
--- a/src/main/java/org/parabot/Landing.java
+++ b/src/main/java/org/parabot/Landing.java
@@ -35,6 +35,11 @@ public final class Landing {
             System.exit(0);
         }
 
+        if(!System.getProperty("os.arch").contains("64")) {
+            UILog.log("Parabot", "You are not running a 64-bit version of java, this might cause the client to lag or crash unexpectedly.\r\n" +
+                    "It's recommended to upgrade to a 64-bit version.");
+        }
+
         parseArgs(args);
 
         Directories.validate();

--- a/src/main/java/org/parabot/Landing.java
+++ b/src/main/java/org/parabot/Landing.java
@@ -36,7 +36,7 @@ public final class Landing {
         }
 
         if(!System.getProperty("os.arch").contains("64")) {
-            UILog.log("Parabot", "You are not running a 64-bit version of java, this might cause the client to lag or crash unexpectedly.\r\n" +
+            UILog.log("Parabot", "You are not running a 64-bit version of Java, this might cause the client to lag or crash unexpectedly.\r\n" +
                     "It's recommended to upgrade to a 64-bit version.");
         }
 


### PR DESCRIPTION
Resolves issue #272 

I don't have the time and patience to test each and every version of java on different operating systems, but here are some links to back the code up:

os.arch property explained:
https://mark.koli.ch/javas-osarch-system-property-is-the-bitness-of-the-jre-not-the-operating-system

os.arch as seen in other projects:
https://github.com/rachelxqy/EligibilityCriteriaModeling/blob/57001f6d86084f074f4ca6aaff157e93ef6abf95/src/main/java/edu/mayo/bmi/medtagger/ml/util/PlatformDetection.java#L28

https://github.com/trustin/os-maven-plugin/blob/master/src/main/java/kr/motd/maven/os/Detector.java#L175

As seen in other projects everytime the os.arch property contains 64 the installed version is 64-bit, meaning a simple .contains("64") is sufficient.

Here is a screenshot of the warning: https://prnt.sc/lnsqgg