### PR TITLE
Improv/xml hook additions

### DIFF
--- a/src/main/java/org/parabot/core/Context.java
+++ b/src/main/java/org/parabot/core/Context.java
@@ -218,6 +218,7 @@ public class Context {
         gameApplet.start();
 
         serverProvider.postAppletStart();
+        getHookParser().verifyHooks();
 
         java.util.Timer t = new java.util.Timer();
         t.schedule(new TimerTask() {

--- a/src/main/java/org/parabot/core/asm/ASMUtils.java
+++ b/src/main/java/org/parabot/core/asm/ASMUtils.java
@@ -22,6 +22,7 @@ public class ASMUtils implements Opcodes {
                 return fieldNodeObject;
             }
         }
+        System.err.println("WARNING: no field found for "+node.name+"."+fieldName);
         return null;
     }
 
@@ -29,6 +30,8 @@ public class ASMUtils implements Opcodes {
         if (desc == null) {
             return getField(node, fieldName);
         }
+        if (node.fields == null)
+            throw new NullPointerException("null fields for "+node.name);
         for (final Object fieldNode : node.fields) {
             FieldNode fieldNodeObject = (FieldNode) fieldNode;
             if (fieldNodeObject.name.equals(fieldName) && fieldNodeObject.desc.equals(desc)) {
@@ -45,6 +48,7 @@ public class ASMUtils implements Opcodes {
                 return node;
             }
         }
+        System.err.println("WARN: failed to find class named: "+className);
         return null;
     }
 
@@ -61,6 +65,7 @@ public class ASMUtils implements Opcodes {
                 return methodNode;
             }
         }
+        System.err.println("WARNING: no Method found for "+location.name+"."+methodName+" "+methodDesc);
         return null;
     }
 

--- a/src/main/java/org/parabot/core/asm/ASMUtils.java
+++ b/src/main/java/org/parabot/core/asm/ASMUtils.java
@@ -38,6 +38,7 @@ public class ASMUtils implements Opcodes {
                 return fieldNodeObject;
             }
         }
+        System.err.println("WARN: failed to find field named: "+node.name+"."+fieldName+" "+desc);
         return null;
     }
 

--- a/src/main/java/org/parabot/core/asm/adapters/AddCallbackAdapter.java
+++ b/src/main/java/org/parabot/core/asm/adapters/AddCallbackAdapter.java
@@ -4,10 +4,12 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
+import org.parabot.core.Core;
 import org.parabot.core.asm.ASMUtils;
 import org.parabot.core.asm.interfaces.Injectable;
 
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 
 /**
  * Injects a callback, invokes a given static method
@@ -34,7 +36,20 @@ public class AddCallbackAdapter implements Injectable, Opcodes {
     }
 
     @Override
+    public String toString() {
+        return "AddCallbackAdapter{" +
+                "method=" + method.name +
+                ", invokeClass='" + invokeClass + '\'' +
+                ", invokeMethod='" + invokeMethod + '\'' +
+                ", desc='" + desc + '\'' +
+                ", args=" + Arrays.toString(args) +
+                ", conditional=" + conditional +
+                '}';
+    }
+
+    @Override
     public void inject() {
+        Core.verbose("Injecting: " + this.toString());
         final Type[] types  = Type.getArgumentTypes(this.method.desc);
         InsnList     inject = new InsnList();
         Label        l0     = new Label();

--- a/src/main/java/org/parabot/core/asm/adapters/AddDebugAdapter.java
+++ b/src/main/java/org/parabot/core/asm/adapters/AddDebugAdapter.java
@@ -3,6 +3,7 @@ package org.parabot.core.asm.adapters;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
+import org.parabot.core.Core;
 
 public class AddDebugAdapter {
     private ClassNode  owner;
@@ -17,7 +18,16 @@ public class AddDebugAdapter {
         this.mn = mn;
     }
 
+    @Override
+    public String toString() {
+        return "AddDebugAdapter{" +
+                "owner=" + owner +
+                ", mn=" + mn +
+                '}';
+    }
+
     public void inject() {
+        Core.verbose("Injecting: " + this.toString());
         InsnList inject = new InsnList();
         Label    l0     = new Label();
         inject.add(new LabelNode(l0));

--- a/src/main/java/org/parabot/core/asm/adapters/AddInvokerAdapter.java
+++ b/src/main/java/org/parabot/core/asm/adapters/AddInvokerAdapter.java
@@ -4,6 +4,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.parabot.core.Core;
 import org.parabot.core.asm.ASMUtils;
 import org.parabot.core.asm.interfaces.Injectable;
 
@@ -48,7 +49,26 @@ public class AddInvokerAdapter implements Opcodes, Injectable {
     }
 
     @Override
+    public String toString() {
+        return "AddInvokerAdapter{" +
+                "into=" + into.name +
+                ", methodLocation=" + methodLocation.name +
+                ", mn=" + mn.name +
+                ", argsDesc='" + argsDesc + '\'' +
+                ", returnDesc='" + returnDesc + '\'' +
+                ", methodName='" + methodName + '\'' +
+                ", isInterface=" + isInterface +
+                ", instanceCast='" + instanceCast + '\'' +
+                ", mName='" + mName + '\'' +
+                ", mDesc='" + mDesc + '\'' +
+                ", argsCheckCast='" + argsCheckCast + '\'' +
+                ", isStatic=" + isStatic +
+                '}';
+    }
+
+    @Override
     public void inject() {
+        Core.verbose("Injecting: " + this.toString());
         String mArgsDesc = argsCheckCast == null ? this.argsDesc : this.argsCheckCast;
 
         MethodNode m = new MethodNode(ACC_PUBLIC, this.methodName,

--- a/src/main/java/org/parabot/core/asm/adapters/AddInvokerAdapter.java
+++ b/src/main/java/org/parabot/core/asm/adapters/AddInvokerAdapter.java
@@ -129,6 +129,7 @@ public class AddInvokerAdapter implements Opcodes, Injectable {
 
         m.visitInsn(ASMUtils.getReturnOpcode(this.returnDesc));
         m.visitMaxs(0, 0);
+       //System.out.println("invoker: inserted method "+m.name + m.desc+" \t"+m.access+" "+m.signature);
         this.into.methods.add(m);
     }
 

--- a/src/main/java/org/parabot/core/asm/wrappers/Getter.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Getter.java
@@ -7,6 +7,8 @@ import org.parabot.core.asm.ASMUtils;
 import org.parabot.core.asm.adapters.AddGetterAdapter;
 import org.parabot.core.asm.interfaces.Injectable;
 
+import java.util.Arrays;
+
 /**
  * This class injects a getter which gets a specific field
  *
@@ -34,14 +36,19 @@ public class Getter implements Injectable {
     public Getter(final String into, final String fieldLocation, final String fieldNode,
                   final String methodName, final String returnDesc, final boolean staticMethod, final long multiplier,
                   final String fieldDesc) {
-        this.into = ASMUtils.getClass(into);
-        this.fieldLocation = ASMUtils.getClass(fieldLocation);
-        this.fieldNode = ASMUtils.getField(ASMUtils.getClass(fieldLocation), fieldNode, fieldDesc);
-        this.methodName = methodName;
-        this.returnDesc = (returnDesc == null && this.fieldNode != null) ? this.fieldNode.desc : returnDesc;
-        this.staticMethod = staticMethod;
-        this.multiplier = multiplier;
-        Core.verbose(methodName + "[" + fieldLocation + "." + fieldNode + "]");
+        try {
+            this.into = ASMUtils.getClass(into);
+            this.fieldLocation = ASMUtils.getClass(fieldLocation);
+            this.fieldNode = ASMUtils.getField(ASMUtils.getClass(fieldLocation), fieldNode, fieldDesc);
+            this.methodName = methodName;
+            this.returnDesc = (returnDesc == null && this.fieldNode != null) ? this.fieldNode.desc : returnDesc;
+            this.staticMethod = staticMethod;
+            this.multiplier = multiplier;
+            Core.verbose("Getter: " + methodName + "[" + fieldLocation + "." + fieldNode + "]");
+        } catch (Exception e) {
+            System.err.println("Exception in getter init - " + Arrays.toString(new String[]{ into, fieldLocation, fieldNode, methodName, returnDesc, String.valueOf(staticMethod), String.valueOf(multiplier), fieldDesc }));
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
@@ -51,11 +51,15 @@ public class Invoker implements Injectable {
     private static MethodNode getMethod(ClassNode into, String name, String argsDesc, String returnDesc) {
     	for (Object method : into.methods) {
 			MethodNode m = (MethodNode) method;
-			if (m.name.equals(name) &&  m.desc.substring(0, m.desc.indexOf(')') + 1).equals(argsDesc)
+			if (!m.name.equals(name))
+			    continue;
+            //System.out.println("comparing invoker... "+m.desc.substring(0, m.desc.indexOf(')') + 1)+" vs "+argsDesc+" and "+(returnDesc == null ? "" :  Type.getType(m.desc).getReturnType().getDescriptor())+" vs "+returnDesc);
+			if (m.desc.substring(0, m.desc.indexOf(')') + 1).equals(argsDesc)
 					&& (returnDesc == null || Type.getType(m.desc).getReturnType().getDescriptor().equals(returnDesc))) {
 				return m;
 			}
 		}
+        System.err.println("WARNING: no methodnode found for "+into.name+"."+name+" \t "+argsDesc+" -> "+returnDesc);
 		return null;
     }
 

--- a/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
+++ b/src/main/java/org/parabot/core/asm/wrappers/Invoker.java
@@ -34,17 +34,21 @@ public class Invoker implements Injectable {
 
     public Invoker(String into, String methodLoc, String invMethName,
                    String argsDesc, String returnDesc, String methodName, boolean isInterface, String instanceCast, String argsCheckCastDesc) {
+        this(into, methodLoc, invMethName, argsDesc, returnDesc, methodName, isInterface, instanceCast, argsCheckCastDesc, returnDesc);
+    }
+    public Invoker(String into, String methodLoc, String invMethName,
+                   String argsDesc, String returnDesc, String methodName, boolean isInterface, String instanceCast, String argsCheckCastDesc, String invokerReturnDesc) {
         this.into = ASMUtils.getClass(into);
         this.methodLocation = ASMUtils.getClass(methodLoc);
         this.mn = getMethod(this.methodLocation, invMethName, argsDesc, returnDesc);
-        this.returnDesc = returnDesc;
+        this.returnDesc = invokerReturnDesc;
         this.methodName = methodName;
         this.argsDesc = argsDesc;
         this.isInterface = isInterface;
         this.instanceCast = instanceCast;
 
         this.mName = invMethName;
-        this.mDesc = argsDesc + returnDesc;
+        this.mDesc = argsDesc + invokerReturnDesc;
         this.argsCheckCastDesc = argsCheckCastDesc;
     }
 

--- a/src/main/java/org/parabot/core/paint/AbstractDebugger.java
+++ b/src/main/java/org/parabot/core/paint/AbstractDebugger.java
@@ -12,7 +12,7 @@ public abstract class AbstractDebugger implements Paintable {
     /**
      * Toggles this debugger
      */
-    public abstract void toggle();
+    public abstract void toggle() throws ClassCastException;
 
     /**
      * @return True if this debugger is enabled, otherwise false

--- a/src/main/java/org/parabot/core/paint/PaintDebugger.java
+++ b/src/main/java/org/parabot/core/paint/PaintDebugger.java
@@ -57,7 +57,15 @@ public class PaintDebugger {
     }
 
     public final void toggle(final String name) {
-        debuggers.get(name).toggle();
+        if (debuggers.containsKey(name)) {
+            try {
+                debuggers.get(name).toggle();
+            } catch (ClassCastException e) {
+                System.err.println("[Paint] toggle() - you probably need a <descfield> tag on this hook! Exception: "+e);
+            }
+        } else {
+            System.err.println("No such debugger to toggle: " + name);
+        }
     }
 
     public final boolean isEnabled(final String name) {

--- a/src/main/java/org/parabot/core/paint/PaintDebugger.java
+++ b/src/main/java/org/parabot/core/paint/PaintDebugger.java
@@ -4,6 +4,7 @@ import org.parabot.core.Context;
 
 import java.awt.*;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -30,9 +31,17 @@ public class PaintDebugger {
     }
 
     public void debug(Graphics g) {
-        for (final AbstractDebugger d : debuggers.values()) {
+        for (Iterator<AbstractDebugger> iterator = debuggers.values().iterator();
+             iterator.hasNext(); ) {
+            final AbstractDebugger d = iterator.next();
             if (d.isEnabled()) {
-                d.paint(g);
+                try {
+                    d.paint(g);
+                } catch (Exception e) {
+                    iterator.remove();
+                    System.err.println("[PaintDebugger] Error while painting " + d.getClass().getName() + ". The debugger has been removed, you must restart Parabot to enable it again once the issue is fixed. Exception: " + e);
+                    e.printStackTrace();
+                }
             }
         }
         g.setColor(Color.green);

--- a/src/main/java/org/parabot/core/parsers/hooks/HookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/HookParser.java
@@ -63,4 +63,6 @@ public abstract class HookParser {
         return injectables.toArray(new Injectable[injectables.size()]);
     }
 
+    public abstract void verifyHooks();
+
 }

--- a/src/main/java/org/parabot/core/parsers/hooks/JSONHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/JSONHookParser.java
@@ -238,4 +238,9 @@ public class JSONHookParser extends HookParser {
 
         return this.constants;
     }
+
+    @Override
+    public void verifyHooks() {
+
+    }
 }

--- a/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
@@ -192,10 +192,14 @@ public class XMLHookParser extends HookParser {
                         "You'll need to parse interfaces first.");
             }
             final String className = isSet("classname", addGetter) ? getValue(
-                    "classname", addGetter) : interfaceMap.get(getValue(
+                    "classname", addGetter) : getInterMapValue(getValue(
                     "accessor", addGetter));
-            final String into = isSet("into", addGetter) ? getValue("into",
+            String into = isSet("into", addGetter) ? getValue("into",
                     addGetter) : className;
+            if (into != null && into.contains("%s")) { // replacement target
+                into = getInterMapValue(into.substring(into.indexOf("%s") + 2));
+                System.out.println("Getters() -> into replaced with "+into);
+            }
             final long   multiplier = isSet("multiplier", addGetter) ? Long.parseLong(getValue("multiplier", addGetter)) : 0L;
             final String fieldName  = getValue("field", addGetter);
             final String fieldDesc  = isSet("descfield", addGetter) ? getValue("descfield", addGetter) : null;
@@ -267,7 +271,7 @@ public class XMLHookParser extends HookParser {
                         "You'll need to parse interfaces first.");
             }
             final String className = isSet("classname", addSetter) ? getValue(
-                    "classname", addSetter) : interfaceMap.get(getValue(
+                    "classname", addSetter) : getInterMapValue(getValue(
                     "accessor", addSetter));
             final String into = isSet("into", addSetter) ? getValue("into",
                     addSetter) : className;
@@ -340,15 +344,27 @@ public class XMLHookParser extends HookParser {
                         "You'll need to parse interfaces first.");
             }
             final String className = isSet("classname", addInvoker) ? getValue(
-                    "classname", addInvoker) : interfaceMap.get(getValue(
+                    "classname", addInvoker) : getInterMapValue(getValue(
                     "accessor", addInvoker));
-            final String into = isSet("into", addInvoker) ? getValue("into",
+            String into = isSet("into", addInvoker) ? getValue("into",
                     addInvoker) : className;
+            final String prevInto = into;
+            if (into != null && into.contains("%s")) { // replacement target
+                into = getInterMapValue(into.substring(into.indexOf("%s") + 2));
+                System.out.println("Invokers() -> into '"+prevInto+"' replaced with "+into);
+            }
             final String methodName    = getValue("methodname", addInvoker);
             final String invMethodName = getValue("invokemethod", addInvoker);
             final String argsDesc      = getValue("argsdesc", addInvoker);
-            String returnDesc = isSet("desc", addInvoker) ? resolveDesc(getValue(
-                    "desc", addInvoker)) : null;
+            String returnDesc = isSet("desc", addInvoker) ? getValue(
+                    "desc", addInvoker) : null;
+            if (returnDesc != null && returnDesc.contains("%s")) {
+                final String prevReturnDesc = returnDesc;
+                returnDesc = "L" + getInterMapValue(returnDesc.substring(returnDesc.indexOf("%s") + 2)) + ";";
+                System.out.println("Invokers() -> returnDesc '"+prevReturnDesc+"' replaced with "+returnDesc);
+            } else {
+                returnDesc = resolveDesc(returnDesc);
+            }
 
             final boolean isInterface       = isSet("interface", addInvoker) ? Boolean.parseBoolean(getValue("interface", addInvoker)) : false;
             final String  instanceCast      = isSet("instancecast", addInvoker) ? getValue("instancecast", addInvoker) : null;
@@ -359,6 +375,12 @@ public class XMLHookParser extends HookParser {
             invokerList.add(invoker);
         }
         return invokerList.toArray(new Invoker[invokerList.size()]);
+    }
+
+    public String getInterMapValue(String key) {
+        if (!interfaceMap.containsKey(key))
+            throw new RuntimeException("no interface by name: "+key);
+        return interfaceMap.get(key);
     }
 
     @Override
@@ -438,7 +460,7 @@ public class XMLHookParser extends HookParser {
                         "You'll need to parse interfaces first.");
             }
             final String className = isSet("classname", addCallback) ? getValue(
-                    "classname", addCallback) : interfaceMap.get(getValue(
+                    "classname", addCallback) : getInterMapValue(getValue(
                     "accessor", addCallback));
 
             final String  methodName  = getValue("methodname", addCallback);

--- a/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
@@ -114,7 +114,7 @@ public class XMLHookParser extends HookParser {
                         }
                     }
                     if (!found) {
-                        System.err.println("A hook you've added doesn't exist in the API!! "+api+"."+methodName);
+                        System.err.println("A hook you've added doesn't exist in the API!! "+api+"."+methodName+" \t\t"+fieldDesc+" --> "+returnDesc);
                     }
                 } catch (ClassNotFoundException e) {
                     e.printStackTrace();

--- a/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
@@ -66,11 +66,8 @@ public class XMLHookParser extends HookParser {
 
             String into = parser.isSet("into", addGetter) ? parser.getValue("into",
                     addGetter) : className;
-            final String prevInto = into;
-            if (into != null && into.contains("%s")) { // replacement target
-                into = parser.getInterMapValue(into.substring(into.indexOf("%s") + 2));
-                System.out.println("Getters() -> into '"+prevInto+"' replaced with "+into);
-            }
+            if (into != null)
+                into = resolveRealFromInter(into, true);
             final long   multiplier = parser.isSet("multiplier", addGetter) ? Long.parseLong(parser.getValue("multiplier", addGetter)) : 0L;
             final String fieldName  = parser.getValue("field", addGetter);
             final String fieldDesc  = parser.isSet("descfield", addGetter) ? parser.getValue("descfield", addGetter) : null;
@@ -79,24 +76,8 @@ public class XMLHookParser extends HookParser {
                     "methstatic", addGetter).equals("true")) : false;
             String returnDesc = parser.isSet("desc", addGetter) ? parser.getValue("desc",
                     addGetter) : null;
-            String array = "";
-            if (returnDesc != null && returnDesc.contains("%s")) {
-                StringBuilder str = new StringBuilder();
-                if (returnDesc.startsWith("[")) {
-                    for (int i = 0; i < returnDesc.length(); i++) {
-                        if (returnDesc.charAt(i) == '[') {
-                            array += '[';
-                        }
-                    }
-                    returnDesc = returnDesc.replaceAll("\\[", "");
-                }
-                str.append(array)
-                        .append('L')
-                        .append(String.format(returnDesc,
-                                AddInterfaceAdapter.getAccessorPackage()))
-                        .append(";");
-                returnDesc = str.toString();
-            }
+            if (returnDesc != null)
+                returnDesc = resolveDesc(returnDesc);
 
             if (parser.isSet("accessor", addGetter)) {
                 String a = parser.getValue("accessor", addGetter);
@@ -362,24 +343,8 @@ public class XMLHookParser extends HookParser {
                     "methstatic", addGetter).equals("true")) : false;
             String returnDesc = isSet("desc", addGetter) ? getValue("desc",
                     addGetter) : null;
-            String array = "";
-            if (returnDesc != null && returnDesc.contains("%s")) {
-                StringBuilder str = new StringBuilder();
-                if (returnDesc.startsWith("[")) {
-                    for (int i = 0; i < returnDesc.length(); i++) {
-                        if (returnDesc.charAt(i) == '[') {
-                            array += '[';
-                        }
-                    }
-                    returnDesc = returnDesc.replaceAll("\\[", "");
-                }
-                str.append(array)
-                        .append('L')
-                        .append(String.format(returnDesc,
-                                AddInterfaceAdapter.getAccessorPackage()))
-                        .append(";");
-                returnDesc = str.toString();
-            }
+            if (returnDesc != null)
+                returnDesc = resolveDesc(returnDesc);
             final Getter get = new Getter(into, className, fieldName,
                     methodName, returnDesc, staticMethod, multiplier, fieldDesc);
             getterList.add(get);
@@ -436,24 +401,8 @@ public class XMLHookParser extends HookParser {
                     "methstatic", addSetter).equals("true")) : false;
             String returnDesc = isSet("desc", addSetter) ? getValue("desc",
                     addSetter) : null;
-            String array = "";
-            if (returnDesc != null && returnDesc.contains("%s")) {
-                StringBuilder str = new StringBuilder();
-                if (returnDesc.startsWith("[")) {
-                    for (int i = 0; i < returnDesc.length(); i++) {
-                        if (returnDesc.charAt(i) == '[') {
-                            array += '[';
-                        }
-                    }
-                    returnDesc = returnDesc.replaceAll("\\[", "");
-                }
-                str.append(array)
-                        .append('L')
-                        .append(String.format(returnDesc,
-                                AddInterfaceAdapter.getAccessorPackage()))
-                        .append(";");
-                returnDesc = str.toString();
-            }
+            if (returnDesc != null)
+                returnDesc = resolveDesc(returnDesc);
             final Setter get = new Setter(className, into, fieldName,
                     methodName, returnDesc, staticMethod, fieldDesc);
             setterList.add(get);
@@ -502,7 +451,7 @@ public class XMLHookParser extends HookParser {
                     "accessor", addInvoker));
             String into = isSet("into", addInvoker) ? getValue("into",
                     addInvoker) : className;
-            final String prevInto = into;
+
             if (into != null)
                 into = resolveRealFromInter(into, true);
             final String methodName    = getValue("methodname", addInvoker);
@@ -534,6 +483,7 @@ public class XMLHookParser extends HookParser {
     public String resolveRealFromInter(String returnDesc) {
         return resolveRealFromInter(returnDesc, false);
     }
+
     public String resolveRealFromInter(String returnDesc, boolean ignoreClassPrefix) {
         String array = "";
         final String old = returnDesc;

--- a/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
+++ b/src/main/java/org/parabot/core/parsers/hooks/XMLHookParser.java
@@ -511,12 +511,22 @@ public class XMLHookParser extends HookParser {
                 returnDesc = resolveDesc(returnDesc);
             }
 
+            String invokeReturnDesc = isSet("invokereturndesc", addInvoker) ? getValue(
+                    "invokereturndesc", addInvoker) : returnDesc;
+            if (invokeReturnDesc != null && invokeReturnDesc.contains("%s")) {
+                final String prevReturnDesc = invokeReturnDesc;
+                invokeReturnDesc = "L" + getInterMapValue(invokeReturnDesc.substring(invokeReturnDesc.indexOf("%s") + 2)) + ";";
+                System.out.println("Invokers() -> returnDesc '"+prevReturnDesc+"' replaced with "+invokeReturnDesc);
+            } else {
+                invokeReturnDesc = resolveDesc(invokeReturnDesc);
+            }
+
             final boolean isInterface       = isSet("interface", addInvoker) ? Boolean.parseBoolean(getValue("interface", addInvoker)) : false;
             final String  instanceCast      = isSet("instancecast", addInvoker) ? getValue("instancecast", addInvoker) : null;
             final String  checkCastArgsDesc = isSet("castargs", addInvoker) ? getValue("castargs", addInvoker) : null;
 
             final Invoker invoker = new Invoker(into, className, invMethodName,
-                    argsDesc, returnDesc, methodName, isInterface, instanceCast, checkCastArgsDesc);
+                    argsDesc, returnDesc, methodName, isInterface, instanceCast, checkCastArgsDesc, invokeReturnDesc);
             invokerList.add(invoker);
         }
         return invokerList.toArray(new Invoker[invokerList.size()]);

--- a/src/main/java/org/parabot/environment/servers/ServerProvider.java
+++ b/src/main/java/org/parabot/environment/servers/ServerProvider.java
@@ -3,6 +3,7 @@ package org.parabot.environment.servers;
 import org.objectweb.asm.Opcodes;
 import org.parabot.core.Configuration;
 import org.parabot.core.Context;
+import org.parabot.core.Core;
 import org.parabot.core.asm.hooks.HookFile;
 import org.parabot.core.asm.interfaces.Injectable;
 import org.parabot.core.parsers.hooks.HookParser;
@@ -79,6 +80,7 @@ public abstract class ServerProvider implements Opcodes {
 
         HookParser   parser      = hookFile.getParser();
         Injectable[] injectables = parser.getInjectables();
+        Core.verbose("[ServerProvider] HookParser parsed "+injectables.length+" injectables!");
 
         if (injectables == null) {
             return;

--- a/src/test/java/org/parabot/ClassNameTest.java
+++ b/src/test/java/org/parabot/ClassNameTest.java
@@ -1,0 +1,79 @@
+package org.parabot;
+
+import org.junit.Test;
+import org.parabot.core.asm.adapters.AddInterfaceAdapter;
+import org.parabot.core.parsers.hooks.XMLHookParser;
+
+import java.util.HashMap;
+
+public class ClassNameTest {
+
+    @Test
+    public void name() {
+        AddInterfaceAdapter.setAccessorPackage("org.parabot.novea.");
+        String x1, s;
+
+        x1 = "%sRenderable";
+        s  = XMLHookParser.resolveDesc(x1);
+        System.out.println(s);
+
+        x1 = "[[%sRenderable";
+        s  = XMLHookParser.resolveDesc(x1);
+        System.out.println(s);
+
+        x1 = "[[I";
+        s  = XMLHookParser.resolveDesc(x1);
+        System.out.println(s);
+        System.out.println();
+
+        x1 = "%sRenderable";
+        s  = resolveRealFromInter(x1);
+        System.out.println(s);
+
+        x1 = "[[%sRenderable";
+        s  = resolveRealFromInter(x1);
+        System.out.println(s);
+
+        x1 = "[[I";
+        s  = resolveRealFromInter(x1);
+        System.out.println(s);
+
+    }
+
+    public static String resolveRealFromInter(String returnDesc) {
+        String array = "";
+        if (returnDesc != null && returnDesc.contains("%s")) {
+            StringBuilder str = new StringBuilder();
+            if (returnDesc.startsWith("[")) {
+                for (int i = 0; i < returnDesc.length(); i++) {
+                    if (returnDesc.charAt(i) == '[') {
+                        array += '[';
+                    }
+                }
+                returnDesc = returnDesc.replaceAll("\\[", "");
+            }
+            String key = returnDesc.substring(returnDesc.indexOf("%s") + 2);
+            returnDesc = returnDesc.replaceAll(key, "");
+            str.append(array)
+                    .append('L')
+                    .append(String.format(returnDesc,
+                            getInterMapValue2(key)))
+                    .append(";");
+            returnDesc = str.toString();
+        }
+        return returnDesc;
+    }
+
+    private static HashMap<String, String> interfaceMap;
+
+    public static String getInterMapValue2(String key) {
+        if (!interfaceMap.containsKey(key))
+            throw new RuntimeException("no interface by name: "+key);
+        return interfaceMap.get(key);
+    }
+
+    static {
+        interfaceMap = new HashMap<>(0);
+        interfaceMap.put("Renderable", "bL");
+    }
+}


### PR DESCRIPTION
adds `getHookParser().verifyHooks();` which is based on the `[]getGetters()` method. 

It parses the xml as usual then looks for matches of the `<into>` and `<accessor>` target hooks to equivalent methods in the API under `AddInterfaceAdapter.getAccessorsPath()` such as `org.parabot.accessors.Client:getLocalPlayers() [Lplayer;`

Any issues appear in sys.err rather than bringing up a UI notification (current UIs are blocking) if there are multiple issues the user would have to close every blocking prompt to see the prints. 

also

- add missing `Injecting: xx` prints to invoker & callback
- add new `invokerReturnDesc` xml tag to `invokers` allowing for non `V` return types support (see below for discussion)
- added exception catch for painting debugs, when an exception is thrown the debug is removed instead of repainting every millisecond and spamming the console with errors.


**invokerReturnDesc**
Surely invokers already supported returning types? Nope!
in `317-min-api` :

- `getNpcDef` is not static and hence an invoker is not needed, only a getter in `Npc`
- `getItemDefinition`  IS static, but never called. `name` is hardcode loaded from an external xml file
- `getObjectDefinition` IS static, but once again never called. 317-api offers no `name` for objects!