### PR TITLE
Make server selection scrollbar not super slow

### DIFF
--- a/src/main/java/org/parabot/core/ui/ServerSelector.java
+++ b/src/main/java/org/parabot/core/ui/ServerSelector.java
@@ -56,6 +56,8 @@ public class ServerSelector extends JPanel {
                 .setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
         scrlInterior
                 .setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
+        scrlInterior
+                .getVerticalScrollBar().setUnitIncrement(16);
         add(scrlInterior);
 
     }


### PR DESCRIPTION
This always bothered me (might have been a Linux issue?), figured I'd fix it. It should be consistent now.