### PR TITLE
Fix Run getting laggier and laggier every time

### DIFF
--- a/src/main/java/org/parabot/core/parsers/scripts/ScriptParser.java
+++ b/src/main/java/org/parabot/core/parsers/scripts/ScriptParser.java
@@ -22,6 +22,7 @@ public abstract class ScriptParser {
 
     public static ScriptDescription[] getDescriptions() {
         SCRIPT_CACHE.clear();
+        parsers.clear();
         if (Core.inLoadLocal()) {
             parsers.add(new LocalJavaScripts());
             parsers.add(new BDNScripts());


### PR DESCRIPTION
I noticed this while scripting my ScriptFactory, which required so many Stops and Runs again. Every time you click "Run", it loops through an ever-increasing arraylist of scripts, making it slower and slower each time until you just restart the client. It looks like whoever wrote this cleared the hashmap, but forgot to clear the array. This fixes the issue.