### PR TITLE
Let the user know how to downgrade to Java 8 if prompted with Java 9+ notification

### DIFF
--- a/src/main/java/org/parabot/Landing.java
+++ b/src/main/java/org/parabot/Landing.java
@@ -30,7 +30,7 @@ public final class Landing {
 //        Thread.setDefaultUncaughtExceptionHandler(new FileExceptionHandler(ExceptionHandler.ExceptionType.CLIENT));
 
         if (Context.getJavaVersion() >= 9) {
-            UILog.log("Parabot", "Parabot doesn't support Java 9+ currently. Please downgrade to Java 8 to ensure Parabot is working correctly.");
+            UILog.log("Parabot", "Parabot doesn't support Java 9+ currently. Get Java 8 at adoptopenjdk.net to ensure Parabot is working correctly.");
         }
 
         if (!System.getProperty("os.arch").contains("64")) {


### PR DESCRIPTION
Simple UX change. New message looks like:

![image](https://user-images.githubusercontent.com/32943174/66171881-c24d6880-e617-11e9-9758-0dd39f6059c6.png)
